### PR TITLE
Review

### DIFF
--- a/auth/token.go
+++ b/auth/token.go
@@ -19,10 +19,10 @@ type (
 )
 
 const (
-	// CbsTokenTypeJwt is the type of token to be used for JWT tokens. For example Azure Active Directory tokens.
-	CbsTokenTypeJwt TokenType = "jwt"
-	// CbsTokenTypeSas is the type of token to be used for SAS tokens.
-	CbsTokenTypeSas TokenType = "servicebus.windows.net:sastoken"
+	// CBSTokenTypeJWT is the type of token to be used for JWTs. For example Azure Active Directory tokens.
+	CBSTokenTypeJWT TokenType = "jwt"
+	// CBSTokenTypeSAS is the type of token to be used for SAS tokens.
+	CBSTokenTypeSAS TokenType = "servicebus.windows.net:sastoken"
 )
 
 // NewToken constructs a new auth token

--- a/cbs/cbs.go
+++ b/cbs/cbs.go
@@ -44,10 +44,11 @@ func NegotiateClaim(ctx context.Context, audience string, conn *amqp.Client, pro
 	}
 
 	res, err := link.RetryableRPC(ctx, 3, 1*time.Second, msg)
-	if err == nil {
-		log.Debugf("negotiated with response code %d and message: %s", res.Code, res.Description)
-	} else {
+	if err != nil {
 		log.Error(err)
+		return err
 	}
-	return err
+
+	log.Debugf("negotiated with response code %d and message: %s", res.Code, res.Description)
+	return nil
 }

--- a/common/retry.go
+++ b/common/retry.go
@@ -4,16 +4,12 @@ import (
 	"time"
 )
 
-type (
-	// Retryable represents an error which should be able to be retried
-	Retryable struct {
-		Message string
-	}
-)
+// Retryable represents an error which should be able to be retried
+type Retryable string
 
 // Error implementation for Retryable
-func (r *Retryable) Error() string {
-	return r.Message
+func (r Retryable) Error() string {
+	return string(r)
 }
 
 // Retry will attempt to retry an action a number of times if the action returns a retryable error
@@ -22,7 +18,7 @@ func Retry(times int, delay time.Duration, action func() (interface{}, error)) (
 	for i := 0; i < times; i++ {
 		item, err := action()
 		if err != nil {
-			if err, ok := err.(*Retryable); ok {
+			if err, ok := err.(Retryable); ok {
 				lastErr = err
 				time.Sleep(delay)
 				continue

--- a/helpers.go
+++ b/helpers.go
@@ -41,9 +41,9 @@ func ptrInt64(number int64) *int64 {
 	return &number
 }
 
-// durationTo8601Seconds takes a duration and returns a string period of whole seconds (int cast of float)
-func durationTo8601Seconds(duration *time.Duration) *string {
-	return ptrString(fmt.Sprintf("PT%dS", int(duration.Seconds())))
+// durationTo8601Seconds takes a duration and returns a string period of whole seconds
+func durationTo8601Seconds(duration time.Duration) *string {
+	return ptrString(fmt.Sprintf("PT%dS", int(duration/time.Second)))
 }
 
 // parseAzureResourceID converts a long-form Azure Resource Manager ID

--- a/hub_test.go
+++ b/hub_test.go
@@ -281,7 +281,7 @@ func BenchmarkReceive(b *testing.B) {
 }
 
 func (suite *eventHubSuite) newClient(t *testing.T, hubName string, opts ...HubOption) Client {
-	provider, err := aad.NewProviderFromEnvironment(aad.JwtTokenProviderWithEnvironment(&suite.env))
+	provider, err := aad.NewProviderFromEnvironment(aad.JWTProviderWithEnvironment(&suite.env))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mgmt/mgmt.go
+++ b/mgmt/mgmt.go
@@ -75,8 +75,8 @@ type (
 		LastSequenceNumber int64
 		// LastEnqueuedOffset is the offset of the last enqueued message in the partition's message log
 		LastEnqueuedOffset string
-		// LastEnqueuedTimeUtc is the time of the last enqueued message in the partition's message log in UTC
-		LastEnqueuedTimeUtc time.Time
+		// LastEnqueuedTimeUTC is the time of the last enqueued message in the partition's message log in UTC
+		LastEnqueuedTimeUTC time.Time
 	}
 )
 
@@ -171,83 +171,83 @@ func (c *Client) getTokenAudience() string {
 
 func newHubPartitionRuntimeInformation(msg *amqp.Message) (*HubPartitionRuntimeInformation, error) {
 	const errMsgFmt = "could not read %q key from message when creating a new hub partition runtime information -- message value: %v"
-	info := new(HubPartitionRuntimeInformation)
 	values, ok := msg.Value.(map[string]interface{})
 	if !ok {
 		return nil, errors.Errorf("values were not map[string]interface{}, it was: %v", values)
 	}
 
-	if hubPath, ok := values[entityNameKey].(string); ok {
-		info.HubPath = hubPath
-	} else {
+	hubPath, ok := values[entityNameKey].(string)
+	if !ok {
 		return nil, errors.Errorf(errMsgFmt, entityNameKey, values)
 	}
 
-	if partition, ok := values[partitionNameKey].(string); ok {
-		info.PartitionID = partition
-	} else {
+	partition, ok := values[partitionNameKey].(string)
+	if !ok {
 		return nil, errors.Errorf(errMsgFmt, partitionNameKey, values)
 	}
 
-	if sequence, ok := values[resultBeginSequenceNumKey].(int64); ok {
-		info.BeginningSequenceNumber = sequence
-	} else {
+	beginSequence, ok := values[resultBeginSequenceNumKey].(int64)
+	if !ok {
 		return nil, errors.Errorf(errMsgFmt, resultBeginSequenceNumKey, values)
 	}
 
-	if sequence, ok := values[resultLastEnqueuedSequenceNumKey].(int64); ok {
-		info.LastSequenceNumber = sequence
-	} else {
+	lastSequence, ok := values[resultLastEnqueuedSequenceNumKey].(int64)
+	if !ok {
 		return nil, errors.Errorf(errMsgFmt, resultLastEnqueuedSequenceNumKey, values)
 	}
 
-	if lastOffset, ok := values[resultLastEnqueuedOffsetKey].(string); ok {
-		info.LastEnqueuedOffset = lastOffset
-	} else {
+	lastOffset, ok := values[resultLastEnqueuedOffsetKey].(string)
+	if !ok {
 		return nil, errors.Errorf(errMsgFmt, resultLastEnqueuedOffsetKey, values)
 	}
 
-	if t, ok := values[resultLastEnqueueTimeUtcKey].(time.Time); ok {
-		info.LastEnqueuedTimeUtc = t
-	} else {
+	lastTime, ok := values[resultLastEnqueueTimeUtcKey].(time.Time)
+	if !ok {
 		return nil, errors.Errorf(errMsgFmt, resultLastEnqueueTimeUtcKey, values)
 	}
 
-	return info, nil
+	return &HubPartitionRuntimeInformation{
+		HubPath:                 hubPath,
+		PartitionID:             partition,
+		BeginningSequenceNumber: beginSequence,
+		LastSequenceNumber:      lastSequence,
+		LastEnqueuedOffset:      lastOffset,
+		LastEnqueuedTimeUTC:     lastTime,
+	}, nil
 }
 
 // newHubRuntimeInformation constructs a new HubRuntimeInformation from an AMQP message
 func newHubRuntimeInformation(msg *amqp.Message) (*HubRuntimeInformation, error) {
 	const errMsgFmt = "could not read %q key from message when creating a new hub runtime information -- message value: %v"
-	info := new(HubRuntimeInformation)
 	values, ok := msg.Value.(map[string]interface{})
 	if !ok {
 		return nil, errors.Errorf("values were not map[string]interface{}, it was: %v", values)
 	}
 
-	if path, ok := values[entityNameKey].(string); ok {
-		info.Path = path
-	} else {
+	path, ok := values[entityNameKey].(string)
+	if !ok {
 		return nil, errors.Errorf(errMsgFmt, entityNameKey, values)
 	}
 
-	if createdAt, ok := values[resultCreatedAtKey].(time.Time); ok {
-		info.CreatedAt = createdAt
-	} else {
+	createdAt, ok := values[resultCreatedAtKey].(time.Time)
+	if !ok {
 		return nil, errors.Errorf(errMsgFmt, resultCreatedAtKey, values)
 	}
 
-	if count, ok := values[resultPartitionCountKey].(int32); ok {
-		info.PartitionCount = int(count)
-	} else {
+	count, ok := values[resultPartitionCountKey].(int32)
+	if !ok {
 		return nil, errors.Errorf(errMsgFmt, resultPartitionCountKey, values)
 	}
 
-	if ids, ok := values[resultPartitionIDsKey].([]string); ok {
-		info.PartitionIDs = ids
-	} else {
+	ids, ok := values[resultPartitionIDsKey].([]string)
+	if !ok {
 		return nil, errors.Errorf(errMsgFmt, resultPartitionCountKey, values)
 	}
 
-	return info, nil
+	return &HubRuntimeInformation{
+		Path:           path,
+		CreatedAt:      createdAt,
+		PartitionCount: int(count),
+		PartitionIDs:   ids,
+	}, nil
 }

--- a/namespace.go
+++ b/namespace.go
@@ -39,23 +39,24 @@ func (ns *namespace) connection() (*amqp.Client, error) {
 	ns.clientMu.Lock()
 	defer ns.clientMu.Unlock()
 
-	if ns.client == nil {
-		host := ns.getAmqpHostURI()
-		client, err := amqp.Dial(
-			host,
-			amqp.ConnSASLAnonymous(),
-			amqp.ConnMaxSessions(65535),
-			amqp.ConnProperty("product", "MSGolangClient"),
-			amqp.ConnProperty("version", "0.0.1"),
-			amqp.ConnProperty("platform", runtime.GOOS),
-			amqp.ConnProperty("framework", runtime.Version()),
-			amqp.ConnProperty("user-agent", rootUserAgent),
-		)
-		if err != nil {
-			return nil, err
-		}
-		ns.client = client
+	if ns.client != nil {
+		return ns.client, nil
 	}
+
+	host := ns.getAmqpHostURI()
+	client, err := amqp.Dial(host,
+		amqp.ConnSASLAnonymous(),
+		amqp.ConnMaxSessions(65535),
+		amqp.ConnProperty("product", "MSGolangClient"),
+		amqp.ConnProperty("version", "0.0.1"),
+		amqp.ConnProperty("platform", runtime.GOOS),
+		amqp.ConnProperty("framework", runtime.Version()),
+		amqp.ConnProperty("user-agent", rootUserAgent),
+	)
+	if err != nil {
+		return nil, err
+	}
+	ns.client = client
 	return ns.client, nil
 }
 


### PR DESCRIPTION
@devigned It took me longer to get this review together than I had intended. Life/work got in the way a bit. Anyway, it's mostly applying idioms and restructuring some pieces. I made a few notes with suggestions and explainations this time around:

### Interfaces

I noticed, particarly in `hub.go`, there are many interfaces defined. Unless there's a concrete reason, I'd suggest only declaring interfaces you're using. While not a hard rule by any means, I also suggest returning values instead of interfaces. There's a good [post](https://medium.com/@cep21/what-accept-interfaces-return-structs-means-in-go-2fe879e25ee8) about this. A concrete reason, in the case of the `Client` interface, is that when a user goes to look at the documentation for `Client`, they'll just see the interface definition with some embedded interfaces. The `hub` type isn't public, so they won't see the documentation associated with the methods. (Run [godoc](https://godoc.org/golang.org/x/tools/cmd/godoc) locally with the `-http` flag to see what it looks like.)

### Client Constructors

There are three constructors for a `Client`. Since you're using functional options, could these be reduced to a single constructor and have options for the variants?

As a bit of an aside, the idea of functional options in Go originally came from a [blog post](https://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html) by Rob Pike and later [advocated for(https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) by Dave Cheney. Both posts are well worth reading if you haven't already.

### Functional options in hot path

This may fall under the category of premature optimization, but I would want to check the escape analysis and possibly do some benchmarking with functional options in the hot path. I suspect they may cause extra allocations. Not something I worry about for APIs that aren't called frequently, but it might be noticeable for methods such as `sender.Send`.

### Logging

Logging within libaries can be a bit of a contentious issue, but the general advice is "Don't. If you really need to, allow the consumer to provide the implementation." The current use of logrus forces consumers to bring in that dependency and if they don't realize the lib may log and they expect a certain log format, it could break their log parsing. (I've had this happen and it's frustrating.)

### Common Package

Packages like `common` and `util` are [considered an anti-pattern](https://blog.golang.org/package-names#TOC_5.).

### Internal Packages

I'm not sure how many of the packages are intended to be exposed to end users. If some are only intended for internal use, I'd suggest putting them in an `internal` directory. This has [special meaning](https://golang.org/cmd/go/#hdr-Internal_Directories) to the toolchain and will prevent others from importing from them.

### Acronym Capitalization

It's idiomatic to use consistent casing for acronyms. So `JWTToken` or `jwtToken` rather than `JwtToken`. (In the PR I also change names to just say `JWT` instead of `JWTToken` to avoid the redundancy.)

### Number of packages

There's no hard rule for number of packages. Personally I try to limit the number in a library. It's a bit annoying to need to go to multiple godoc pages to see the docs I need. I tend to separate out things that are optional and will bring in external dependencies, as well as packages that someone may want to use without the primary library.

### Type declarations

This is a preference thing, but I wanted to mention that declaring types like

``` go
type (
    MyType struct{ ... }
)
```

is a bit unusual. I usually only see that syntax when declaring related types that won't have any methods attached.

### Other minor stuff

* `HubWithUserAgent` doc comment references unexported `maxUserAgentLen`.

    Users will be unable to see the value of `maxUserAgentLen` in godoc.

* `hub.Receive` comment incorrect

    > // Listen subscribes for messages sent to the provided entityPath.

    The name is out of date and there's no `entityPath` argument.

* `MemoryPersister`'s use of `sync.Map`

    [`sync.Map`](https://golang.org/pkg/sync/#Map) is optimized for a particular use case. I assume in the case of storing and updating an offset the value will be updated frequently. I think a regular map with a `sync.RWMutex` may be more appropriate in this case and will retain type safety.
