### PR TITLE
simplify environmental construction by prefering SAS

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,8 +34,8 @@
     "services/storage/mgmt/2017-10-01/storage",
     "version"
   ]
-  revision = "fad8443a79b0e755c18c3bec29a8d2bedab0b421"
-  version = "v15.3.0"
+  revision = "4650843026a7fdec254a8d9cf893693a254edd0b"
+  version = "v16.2.1"
 
 [[projects]]
   name = "github.com/Azure/azure-storage-blob-go"
@@ -191,6 +191,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "24f9aedfb2f0a6e602f946d39cff1cb8900a337bedbc7ce18a3ca5b9334d2876"
+  inputs-digest = "9e8d39c2948233a4f9dc40bdfcbee21ae301de912713e0f0c8c6644668aece5b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,7 +8,7 @@
 
 [[constraint]]
     name = "github.com/Azure/azure-sdk-for-go"
-    version = "15"
+    version = "16"
 
 [[constraint]]
     name = "github.com/Azure/azure-amqp-common-go"

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v0.3.1`
+- simplify environmental construction by prefering SAS
+
 ## `v0.3.0`
 - pin version of amqp
 

--- a/hub.go
+++ b/hub.go
@@ -44,7 +44,7 @@ const (
 	rootUserAgent   = "/golang-event-hubs"
 
 	// Version is the semantic version number
-	Version = "0.3.0"
+	Version = "0.3.1"
 )
 
 type (

--- a/internal/test/suite.go
+++ b/internal/test/suite.go
@@ -174,10 +174,7 @@ func (suite *BaseSuite) DeleteEventHub(ctx context.Context, name string) error {
 
 func (suite *BaseSuite) deleteAllTaggedEventHubs(ctx context.Context) {
 	client := suite.getEventHubMgmtClient()
-	res, err := client.ListByNamespace(ctx, ResourceGroupName, suite.Namespace)
-	if err != nil {
-		suite.FailNow(err.Error())
-	}
+	res, _ := client.ListByNamespace(ctx, ResourceGroupName, suite.Namespace)
 
 	for res.NotDone() {
 		for _, val := range res.Values() {
@@ -286,7 +283,7 @@ func (suite *BaseSuite) ensureNamespace() (*mgmt.EHNamespace, error) {
 }
 
 func (suite *BaseSuite) setupTracing() error {
-	if os.Getenv("CI") != "true" {
+	if os.Getenv("TRACING") == "true" {
 		// Sample configuration for testing. Use constant sampling to sample every trace
 		// and enable LogSpan to log every span via configured Logger.
 		cfg := config.Configuration{


### PR DESCRIPTION
### Fix or Enhancement?
Fixes #38 by short-circuiting upon successful SAS provider construction. This doesn't solve the underlying issues with go-autorest, but will help in this specific case.

- [x] All tests passed
- [x] Add change to `changelog.md`