### PR TITLE
Add option to configure consumer group

### DIFF
--- a/eph/eph.go
+++ b/eph/eph.go
@@ -63,6 +63,7 @@ type (
 		namespace     string
 		hubName       string
 		name          string
+		consumerGroup string
 		tokenProvider auth.TokenProvider
 		client        *eventhub.Hub
 		leaser        Leaser
@@ -96,6 +97,14 @@ type (
 func WithNoBanner() EventProcessorHostOption {
 	return func(host *EventProcessorHost) error {
 		host.noBanner = true
+		return nil
+	}
+}
+
+// WithConsumerGroup will configure an EventProcessorHost to a specific consumer group
+func WithConsumerGroup(consumerGroup string) EventProcessorHostOption {
+	return func(host *EventProcessorHost) error {
+		host.consumerGroup = consumerGroup
 		return nil
 	}
 }

--- a/eph/leasedReceiver.go
+++ b/eph/leasedReceiver.go
@@ -64,9 +64,9 @@ func (lr *leasedReceiver) Run(ctx context.Context) error {
 		lr.periodicallyRenewLease(ctx)
 	}()
 
-	opts := []eventhub.ReceiveOption{
-		eventhub.ReceiveWithEpoch(epoch),
-		eventhub.ReceiveWithConsumerGroup(lr.processor.consumerGroup),
+	opts := []eventhub.ReceiveOption{eventhub.ReceiveWithEpoch(epoch)}
+	if lr.processor.consumerGroup != "" {
+		opts = append(opts, eventhub.ReceiveWithConsumerGroup(lr.processor.consumerGroup))
 	}
 
 	handle, err := lr.processor.client.Receive(ctx, partitionID, lr.processor.compositeHandlers(), opts...)

--- a/eph/leasedReceiver.go
+++ b/eph/leasedReceiver.go
@@ -64,7 +64,12 @@ func (lr *leasedReceiver) Run(ctx context.Context) error {
 		lr.periodicallyRenewLease(ctx)
 	}()
 
-	handle, err := lr.processor.client.Receive(ctx, partitionID, lr.processor.compositeHandlers(), eventhub.ReceiveWithEpoch(epoch))
+	opts := []eventhub.ReceiveOption{
+		eventhub.ReceiveWithEpoch(epoch),
+		eventhub.ReceiveWithConsumerGroup(lr.processor.consumerGroup),
+	}
+
+	handle, err := lr.processor.client.Receive(ctx, partitionID, lr.processor.compositeHandlers(), opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request adds the option to configure an eph to a specific consumer group

### Fix or Enhancement?


- [ ] All tests passed
- [ ] Add change to `changelog.md`

### Environment
- OS: Write here
- Go version: Write here