### PR TITLE
ReceiveFromTimestamp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## `head`
+- add receive option to receive from a timestamp
 
 ## `v1.0.1`
 - fix the breaking change from storage; this is not a breaking change for this library

--- a/receiver.go
+++ b/receiver.go
@@ -98,6 +98,7 @@ func ReceiveWithLatestOffset() ReceiveOption {
 	}
 }
 
+// ReceiveFromTimestamp configures the receiver to start receiving from a specific point in time in the event stream
 func ReceiveFromTimestamp(t time.Time) ReceiveOption {
 	return func(receiver *receiver) error {
 		receiver.storeLastReceivedCheckpoint(persist.NewCheckpoint("", 0, t))


### PR DESCRIPTION

### Fix or Enhancement?

Add `ReceiveFromTimestamp` as a `ReceiveOption` to allow user to start receiving from a specific point in time.

I'm not sure about the naming - please advice if better names exist. I changed it around a bit for it to make sense.

I couldn't find any tests specific to the other receive options, so I haven't added any for this. Please point me to similar tests if needed and such exists.

- [ ] All tests passed

I haven't managed to run tests as they depend on Azure. I'm not sure what it requires. However a manual smoke test shows `Receive` to be working for both start of stream, latest, specific offset and a specific timestamp.

- [x] Add change to `changelog.md`

No. Not sure where to add it? It would be a new version?

### Environment
- OS: Ubuntu
- Go version: 1.10
