### PR TITLE
Fix discarding of event properties on batch sending

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## `head`
+- fix discarding event properties on batch sending
 
 ## `v1.1.2`
 - take dep on updated amqp common which has more permissive RPC status description parsing 

--- a/event.go
+++ b/event.go
@@ -148,7 +148,7 @@ func (b *EventBatch) toEvent() (*Event, error) {
 	}
 
 	for idx, event := range b.Events {
-		innerMsg := amqp.NewMessage(event.Data)
+		innerMsg := event.toMsg()
 		bin, err := innerMsg.MarshalBinary()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Fix or Enhancement?
When sending batch events the message properties are discarded and therefore not received on the consuming side. This is because the inner event message is not properly constructed. This pull request fixes this issue by leveraging the already existing `toMsg()` method.

- [x] All tests passed
- [x] Add change to `changelog.md`

### Environment
- OS: macOS 10.14.2
- Go version: 1.10.3 darwin/amd64