### PR TITLE
travis changed the go module export

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.11.x
 before_install:
   - cd ${TRAVIS_HOME}
+  - export GO111MODULE=auto
   - go get -u github.com/mattn/goveralls
   - go get -u golang.org/x/tools/cmd/cover
   - go get -u github.com/fzipp/gocyclo


### PR DESCRIPTION
Travis changed the way go modules are setup breaking the tool installation before install. This allows for build tool installation outside of module directory without impacting module dependencies.
