### PR TITLE
fix the dirty partition leak

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## `head`
+
+## `v1.1.3`
+- fix leak in partition persistence 
 - fix discarding event properties on batch sending
 
 ## `v1.1.2`

--- a/eph/leasedReceiver.go
+++ b/eph/leasedReceiver.go
@@ -121,7 +121,7 @@ func (lr *leasedReceiver) periodicallyRenewLease(ctx context.Context) {
 			err := lr.tryRenew(ctx)
 			if err != nil {
 				log.For(ctx).Error(err)
-				lr.processor.scheduler.stopReceiver(ctx, lr.lease)
+				_ = lr.processor.scheduler.stopReceiver(ctx, lr.lease)
 			}
 		}
 	}

--- a/hub.go
+++ b/hub.go
@@ -51,7 +51,7 @@ const (
 	rootUserAgent   = "/golang-event-hubs"
 
 	// Version is the semantic version number
-	Version = "1.1.2"
+	Version = "1.1.3"
 )
 
 type (


### PR DESCRIPTION
When calling `len(sl.dirtyPartitions)` in the for loop and `delete(sl.dirtyPartitions, pid)` not all of the channel was consumed, thus leaking the go routine.

This PR snapshots the pids in the beginning of the function to be used in both for loops, and closes the channel if all else fails.

fixes #92 

- [x] All tests passed
- [x] Add change to `changelog.md`