### PR TITLE
sender recovery on conn drops and too large batch test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v1.1.5`
+- add sender recovery handling for `amqp.ErrLinkClose`, `amqp.ErrConnClosed` and `amqp.ErrSessionClosed`
+
 ## `v1.1.4`
 - update to amqp 0.11.0 and change sender to use unsettled rather than receiver second mode
 

--- a/hub.go
+++ b/hub.go
@@ -39,11 +39,13 @@ import (
 	"github.com/Azure/azure-amqp-common-go/log"
 	"github.com/Azure/azure-amqp-common-go/persist"
 	"github.com/Azure/azure-amqp-common-go/sas"
-	"github.com/Azure/azure-event-hubs-go/atom"
 	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
+	"pack.ag/amqp"
+
+	"github.com/Azure/azure-event-hubs-go/atom"
 )
 
 const (
@@ -51,7 +53,7 @@ const (
 	rootUserAgent   = "/golang-event-hubs"
 
 	// Version is the semantic version number
-	Version = "1.1.4"
+	Version = "1.1.5"
 )
 
 type (
@@ -708,6 +710,18 @@ func (h *Hub) getSender(ctx context.Context) (*sender, error) {
 	return h.sender, nil
 }
 
+func isRecoverableCloseError(err error) bool {
+	return isConnectionClosed(err) || isSessionClosed(err) || isLinkClosed(err)
+}
+
 func isConnectionClosed(err error) bool {
-	return err.Error() == "amqp: connection closed"
+	return err == amqp.ErrConnClosed
+}
+
+func isLinkClosed(err error) bool {
+	return err == amqp.ErrLinkClosed
+}
+
+func isSessionClosed(err error) bool {
+	return err == amqp.ErrSessionClosed
 }

--- a/hub_examples_test.go
+++ b/hub_examples_test.go
@@ -17,7 +17,7 @@ func init() {
 	}
 }
 
-func ExampleHub_helloWorld(){
+func ExampleHub_helloWorld() {
 	ctx, cancel := context.WithTimeout(context.Background(), 40*time.Second)
 	defer cancel()
 

--- a/receiver.go
+++ b/receiver.go
@@ -85,24 +85,21 @@ func ReceiveWithConsumerGroup(consumerGroup string) ReceiveOption {
 // ReceiveWithStartingOffset configures the receiver to start at a given position in the event stream
 func ReceiveWithStartingOffset(offset string) ReceiveOption {
 	return func(receiver *receiver) error {
-		receiver.storeLastReceivedCheckpoint(persist.NewCheckpoint(offset, 0, time.Time{}))
-		return nil
+		return receiver.storeLastReceivedCheckpoint(persist.NewCheckpoint(offset, 0, time.Time{}))
 	}
 }
 
 // ReceiveWithLatestOffset configures the receiver to start at a given position in the event stream
 func ReceiveWithLatestOffset() ReceiveOption {
 	return func(receiver *receiver) error {
-		receiver.storeLastReceivedCheckpoint(persist.NewCheckpointFromEndOfStream())
-		return nil
+		return receiver.storeLastReceivedCheckpoint(persist.NewCheckpointFromEndOfStream())
 	}
 }
 
 // ReceiveFromTimestamp configures the receiver to start receiving from a specific point in time in the event stream
 func ReceiveFromTimestamp(t time.Time) ReceiveOption {
 	return func(receiver *receiver) error {
-		receiver.storeLastReceivedCheckpoint(persist.NewCheckpoint("", 0, t))
-		return nil
+		return receiver.storeLastReceivedCheckpoint(persist.NewCheckpoint("", 0, t))
 	}
 }
 
@@ -250,12 +247,22 @@ func (r *receiver) handleMessage(ctx context.Context, msg *amqp.Message, handler
 
 	err := handler(ctx, event)
 	if err != nil {
-		msg.Modify(true, false, nil)
+		err = msg.Modify(true, false, nil)
+		if err != nil {
+			log.For(ctx).Error(err)
+		}
 		log.For(ctx).Error(fmt.Errorf("message modified(true, false, nil): id: %v", id))
 		return
 	}
-	msg.Accept()
-	r.storeLastReceivedCheckpoint(event.GetCheckpoint())
+	err = msg.Accept()
+	if err != nil {
+		log.For(ctx).Error(err)
+	}
+
+	err = r.storeLastReceivedCheckpoint(event.GetCheckpoint())
+	if err != nil {
+		log.For(ctx).Error(err)
+	}
 }
 
 func (r *receiver) listenForMessages(ctx context.Context, msgChan chan *amqp.Message) {
@@ -276,7 +283,7 @@ func (r *receiver) listenForMessages(ctx context.Context, msgChan chan *amqp.Mes
 		default:
 			if amqpErr, ok := err.(*amqp.DetachError); ok && amqpErr.RemoteError != nil && amqpErr.RemoteError.Condition == "amqp:link:stolen" {
 				log.For(ctx).Debug("link has been stolen by a higher epoch")
-				r.Close(ctx)
+				_ = r.Close(ctx)
 				return
 			}
 
@@ -302,7 +309,7 @@ func (r *receiver) listenForMessages(ctx context.Context, msgChan chan *amqp.Mes
 			if retryErr != nil {
 				log.For(ctx).Debug("retried, but error was unrecoverable")
 				r.lastError = retryErr
-				r.Close(ctx)
+				_ = r.Close(ctx)
 				return
 			}
 		}


### PR DESCRIPTION
Fix for sender recovery when we receive conn drops. Also add test for too large of message.

should resolve #100 

- [x] All tests passed
- [x] Add change to `changelog.md`