### PR TITLE
Add SystemProperties to Event

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## `v1.3.0`
+- add `SystemProperties` to `Event` which contains immutable broker provided metadata (squence number, offset, 
+  enqueued time)
+
 ## `v1.2.0`
 - add websocket support
 

--- a/go.sum
+++ b/go.sum
@@ -52,11 +52,9 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
 go.opencensus.io v0.18.0 h1:Mk5rgZcggtbvtAun5aJzAtjKKN/t0R3jJPlWILlv938=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
-golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4 h1:Vk3wNqEZwyGyei9yq5ekj7frek2u7HUfffJ1/opblzc=
 golang.org/x/crypto v0.0.0-20181001203147-e3636079e1a4/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519 h1:x6rhz8Y9CjbgQkccRGmELH6K+LJj7tOoh3XWeC1yaQM=
 golang.org/x/net v0.0.0-20181023162649-9b4f9f5ad519/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/hub.go
+++ b/hub.go
@@ -51,9 +51,6 @@ import (
 const (
 	maxUserAgentLen = 128
 	rootUserAgent   = "/golang-event-hubs"
-
-	// Version is the semantic version number
-	Version = "1.2.0"
 )
 
 type (

--- a/hub_examples_test.go
+++ b/hub_examples_test.go
@@ -97,7 +97,7 @@ func ExampleHub_webSocket() {
 	}
 
 	// Create a client to communicate with EventHub
-	hub, err := eventhub.NewHubFromConnectionString(connStr + ";EntityPath=" + hubEntity.Name, eventhub.HubWithWebSocketConnection())
+	hub, err := eventhub.NewHubFromConnectionString(connStr+";EntityPath="+hubEntity.Name, eventhub.HubWithWebSocketConnection())
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/hub_test.go
+++ b/hub_test.go
@@ -380,6 +380,11 @@ func testBasicSendAndReceive(ctx context.Context, t *testing.T, client *Hub, par
 	count := 0
 	_, err := client.Receive(ctx, partitionID, func(ctx context.Context, event *Event) error {
 		assert.Equal(t, messages[count], string(event.Data))
+		require.NotNil(t, event.SystemProperties)
+		assert.NotNil(t, event.SystemProperties.EnqueuedTime)
+		assert.NotNil(t, event.SystemProperties.Offset)
+		assert.NotNil(t, event.SystemProperties.SequenceNumber)
+		assert.Equal(t, int64(count), *event.SystemProperties.SequenceNumber)
 		count++
 		wg.Done()
 		return nil

--- a/internal/test/suite.go
+++ b/internal/test/suite.go
@@ -220,8 +220,8 @@ func (suite *BaseSuite) deleteAllTaggedEventHubs(ctx context.Context) {
 						break
 					}
 				}
-			} else {
-				suite.T().Logf("%q does not contain %q", *val.Name, suite.TagID)
+			} else if !strings.HasPrefix(*val.Name, "examplehub_") {
+				suite.T().Logf("%q does not contain %q, so it won't be deleted.", *val.Name, suite.TagID)
 			}
 		}
 		suite.NoError(res.Next())

--- a/sender.go
+++ b/sender.go
@@ -53,7 +53,7 @@ type (
 
 	eventer interface {
 		Set(key string, value interface{})
-		toMsg() *amqp.Message
+		toMsg() (*amqp.Message, error)
 	}
 )
 
@@ -152,7 +152,11 @@ func (s *sender) trySend(ctx context.Context, evt eventer) error {
 	defer sp.End()
 
 	evt.Set("_oc_prop", propagation.Binary(sp.SpanContext()))
-	msg := evt.toMsg()
+	msg, err := evt.toMsg()
+	if err != nil {
+		return err
+	}
+
 	if str, ok := msg.Properties.MessageID.(string); ok {
 		sp.AddAttributes(trace.StringAttribute("he.message_id", str))
 	}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+package eventhub
+
+const (
+	// Version is the semantic version number
+	Version = "1.3.0"
+)


### PR DESCRIPTION
### Add `SystemProperties` to `Event`
SystemProperties contains immutable broker provided metadata (squence number, offset, enqueued time).

resolves #99 

- [x] All tests passed
- [x] Add change to `changelog.md`