### PR TITLE
Fix tests for file.go

### DIFF
--- a/persist/file_test.go
+++ b/persist/file_test.go
@@ -49,7 +49,7 @@ func TestFilePersister_Read(t *testing.T) {
 	persister, err := NewFilePersister(dir)
 	assert.Nil(t, err)
 	ckp, err := persister.Read(namespace, name, group, partitionID)
-	assert.Nil(t, err)
+	assert.NotNil(t, err)
 	assert.Equal(t, NewCheckpointFromStartOfStream(), ckp)
 }
 


### PR DESCRIPTION
### Fix or Enhancement?
 [Change](https://github.com/Azure/azure-event-hubs-go/commit/2a12765e337b95d1edeb5c390f67431accf8d938) causes the tests cannot pass in #125 .

When reading a file which does not exist, there should be error.

- [x] All tests passed
- [X] Add change to `changelog.md` (not necessary I think)

### Environment
- OS: Write here
- Go version: Write here