### PR TITLE
fix leaking go routines in storage.(*LeaserCheckpointer).GetLeases

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## `head`
 - enable partitionKey for sendBatch
+- close `leaseCh` on function return in storage.(*LeaserCheckpointer).GetLeases to fix [#136](https://github.com/Azure/azure-event-hubs-go/issues/136)
 
 ## `v2.0.1`
 - update to amqp 0.11.2 & common 2.1.0 to fix [#115](https://github.com/Azure/azure-event-hubs-go/issues/115)

--- a/go.mod
+++ b/go.mod
@@ -26,5 +26,5 @@ require (
 	google.golang.org/api v0.5.0 // indirect
 	google.golang.org/genproto v0.0.0-20190522204451-c2c4e71fbf69 // indirect
 	google.golang.org/grpc v1.21.0 // indirect
-	pack.ag/amqp v0.11.2
+	pack.ag/amqp v0.12.1
 )

--- a/go.sum
+++ b/go.sum
@@ -148,3 +148,4 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 pack.ag/amqp v0.11.2 h1:cuNDWLUTbKRtEZwhB0WQBXf9pGbm87pUBXQhvcFxBWg=
 pack.ag/amqp v0.11.2/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=
+pack.ag/amqp v0.12.1/go.mod h1:4/cbmt4EJXSKlG6LCfWHoqmN0uFdy5i/+YFz+fTfhV4=

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -191,14 +191,18 @@ func (sl *LeaserCheckpointer) GetLeases(ctx context.Context) ([]eph.LeaseMarker,
 
 	partitionIDs := sl.processor.GetPartitionIDs()
 	leaseCh := make(chan leaseGetResult)
-	for idx, partitionID := range partitionIDs {
-		go func(i int, pID string) {
+	defer close(leaseCh)
+
+	for _, partitionID := range partitionIDs {
+		go func(pID string) {
 			lease, err := sl.getLease(ctx, pID)
-			leaseCh <- leaseGetResult{
-				Lease: lease,
-				Err:   err,
+			if ctx.Err() == nil {
+				leaseCh <- leaseGetResult{
+					Lease: lease,
+					Err:   err,
+				}
 			}
-		}(idx, partitionID)
+		}(partitionID)
 	}
 
 	leases := make([]eph.LeaseMarker, len(partitionIDs))

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -196,11 +196,10 @@ func (sl *LeaserCheckpointer) GetLeases(ctx context.Context) ([]eph.LeaseMarker,
 	for _, partitionID := range partitionIDs {
 		go func(pID string) {
 			lease, err := sl.getLease(ctx, pID)
-			if ctx.Err() == nil {
-				leaseCh <- leaseGetResult{
-					Lease: lease,
-					Err:   err,
-				}
+			select {
+			case <-ctx.Done():
+				return
+			case leaseCh <- leaseGetResult{Lease: lease, Err: err}:
 			}
 		}(partitionID)
 	}


### PR DESCRIPTION
Fix #136

### Fix leaking go routines in storage.(*LeaserCheckpointer).GetLeases

- [x] All tests passed
- [x] Add change to `changelog.md`

### Environment
- OS: Write here
- Go version: Write here