### PR TITLE
Bump version to 2.0.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,9 @@
 # Change Log
 
 ## `head`
-- enable partitionKey for sendBatch
+
+## `v2.0.2`
+- enable partitionKey for sendBatch to fix [#128](https://github.com/Azure/azure-event-hubs-go/issues/128)
 - ensure sender receives ack'd messages from EH [#126](https://github.com/Azure/azure-event-hubs-go/issues/126)
 - close `leaseCh` on function return in storage.(*LeaserCheckpointer).GetLeases to fix [#136](https://github.com/Azure/azure-event-hubs-go/issues/136)
 

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package eventhub
 
 const (
 	// Version is the semantic version number
-	Version = "2.0.1"
+	Version = "2.0.2"
 )


### PR DESCRIPTION
### Fix or Enhancement?

@devigned  @jhendrixMSFT I think it is time to bump a new version for event hubs go library now.

- [x] All tests passed
- [x] Add change to `changelog.md`

### Environment
- OS: Write here
- Go version: Write here