### PR TITLE
Prevent sending data to closed lease channel

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## `head`
+- fix send on closed channel for GetLeases
 
 ## `v2.0.2`
 - enable partitionKey for sendBatch to fix [#128](https://github.com/Azure/azure-event-hubs-go/issues/128)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -191,7 +191,6 @@ func (sl *LeaserCheckpointer) GetLeases(ctx context.Context) ([]eph.LeaseMarker,
 
 	partitionIDs := sl.processor.GetPartitionIDs()
 	leaseCh := make(chan leaseGetResult)
-	defer close(leaseCh)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -503,7 +502,6 @@ func (sl *LeaserCheckpointer) persistDirtyPartitions(ctx context.Context) error 
 	defer span.End()
 
 	resCh := make(chan dirtyResult)
-	defer close(resCh)
 
 	// gather all of the dirty partition ids
 	pids := make([]string, len(sl.dirtyPartitions))
@@ -517,9 +515,10 @@ func (sl *LeaserCheckpointer) persistDirtyPartitions(ctx context.Context) error 
 	for _, pid := range pids {
 		go func(id string) {
 			err := sl.persistLease(ctx, id)
-			resCh <- dirtyResult{
-				Err:         err,
-				PartitionID: id,
+			select {
+			case <-ctx.Done():
+				return
+			case resCh <- dirtyResult{PartitionID: id, Err: err}:
 			}
 		}(pid)
 	}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -192,6 +192,8 @@ func (sl *LeaserCheckpointer) GetLeases(ctx context.Context) ([]eph.LeaseMarker,
 	partitionIDs := sl.processor.GetPartitionIDs()
 	leaseCh := make(chan leaseGetResult)
 	defer close(leaseCh)
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	for _, partitionID := range partitionIDs {
 		go func(pID string) {


### PR DESCRIPTION
### Fix or Enhancement?

Make sure no more data is sent to the lease channel before closing it.

resolves #142 

- [x] All tests passed
- [X] Add change to `changelog.md`

### Environment
- OS: Write here
- Go version: Write here