### PR TITLE
Resolution for issue #131

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## `head`
 
+## `v2.0.4`
+- add comment on the `PartitionID` field in `SystemProperties` to clarify that it will always return a nil value [#131](https://github.com/Azure/azure-event-hubs-go/issues/131)
+
 ## `v2.0.3`
 - fix send on closed channel for GetLeases [#142](https://github.com/Azure/azure-event-hubs-go/issues/142)
 

--- a/event.go
+++ b/event.go
@@ -57,7 +57,7 @@ type (
 		SequenceNumber *int64     `mapstructure:"x-opt-sequence-number"` // unique sequence number of the message
 		EnqueuedTime   *time.Time `mapstructure:"x-opt-enqueued-time"`   // time the message landed in the message queue
 		Offset         *int64     `mapstructure:"x-opt-offset"`
-		PartitionID    *int16     `mapstructure:"x-opt-partition-id"`
+		PartitionID    *int16     `mapstructure:"x-opt-partition-id"` // This value will always be nil. For information related to the event's partition refer to the PartitionKey field in this type
 		PartitionKey   *string    `mapstructure:"x-opt-partition-key"`
 	}
 

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package eventhub
 
 const (
 	// Version is the semantic version number
-	Version = "2.0.3"
+	Version = "2.0.4"
 )


### PR DESCRIPTION
### Resolution for issue #131 

Added a comment to the `PartitionID` field on the `SystemProperties` struct to clarify that it will always return nil and that partition related information can be found in the `PartitionKey` field in `SystemProperties`.

Bumped patch version and added log in changelog.md under version `2.0.4`.