### PR TITLE
apply Receive options after populating last stored checkpoint

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## `v3.3.1`
 - fixed panic caused by interface conversion in event.go [#182](https://github.com/Azure/azure-event-hubs-go/issues/182)
+- apply Receive options after populating last stored checkpoint
 
 ## `v3.3.0`
 - add support for sending and receiving custom annotations

--- a/sender.go
+++ b/sender.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/Azure/azure-amqp-common-go/v3/uuid"
@@ -166,7 +167,7 @@ func (s *sender) trySend(ctx context.Context, evt eventer) error {
 
 	recvr := func(err error) {
 		duration := s.recoveryBackoff.Duration()
-		tab.For(ctx).Debug("amqp error, delaying " + string(duration/time.Millisecond) + " millis: " + err.Error())
+		tab.For(ctx).Debug("amqp error, delaying " + strconv.FormatInt(int64(duration/time.Millisecond), 10) + " millis: " + err.Error())
 		time.Sleep(duration)
 		err = s.Recover(ctx)
 		if err != nil {

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package eventhub
 
 const (
 	// Version is the semantic version number
-	Version = "3.3.0"
+	Version = "3.3.1"
 )


### PR DESCRIPTION
Fixes #188 by applying options when setting up a receiver after fetching the stored checkpoint, but before placing the checkpoint back into the persister. This allows any custom offset/timestamp information to be honored when setting up a receiver for a second time on the same consumer group/partition combination.

It's unclear whether the previous behavior was a bug or intentional (not sure what the goal would be if it's intentional). Marked this as a bugfix/patch bump for now on the assumption that the original behavior is a bug.

### Fix or Enhancement?

Fix

- [x] All tests passed - getting one consistent error in `TestBatchSendTooLarge` due to mismatched max batch sizes in the error message (seems unrelated)
- [x] Add change to `changelog.md`

### Environment
- OS: MacOS Catalina
- Go version: 1.15.0