### PR TITLE
EventBatchIterator is longer stuck in a loop if the message batch exceeds the default max size

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -106,7 +106,7 @@ func (ebi *EventBatchIterator) Next(eventID string, opts *BatchOptions) (*EventB
 		}
 	}
 
-	events := ebi.PartitionEventsMap[key]
+	events := ebi.PartitionEventsMap[key][ebi.Cursors[key]:]
 	eb := NewEventBatch(eventID, opts)
 	if key != KeyOfNoPartitionKey && len(events) > 0 {
 		eb.PartitionKey = events[0].PartitionKey


### PR DESCRIPTION
### Fix

- [x] All tests passed
- [ ] Add change to `changelog.md`

### Environment
- OS: macOS 10.15.6
- Go version: 1.15