### PR TITLE
Fix infinite loop in event batch iterator

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -1,6 +1,8 @@
 package eventhub
 
 import (
+	"errors"
+
 	"github.com/Azure/azure-amqp-common-go/v3/uuid"
 	"github.com/Azure/go-amqp"
 )
@@ -46,6 +48,8 @@ const (
 	// KeyOfNoPartitionKey is the key value in Events map for Events which do not have PartitionKey
 	KeyOfNoPartitionKey = "NoPartitionKey"
 )
+
+var ErrMessageIsTooBig = errors.New("message is too big")
 
 // BatchWithMaxSizeInBytes configures the EventBatchIterator to fill the batch to the specified max size in bytes
 func BatchWithMaxSizeInBytes(sizeInBytes int) BatchOption {
@@ -106,7 +110,7 @@ func (ebi *EventBatchIterator) Next(eventID string, opts *BatchOptions) (*EventB
 		}
 	}
 
-	events := ebi.PartitionEventsMap[key]
+	events := ebi.PartitionEventsMap[key][ebi.Cursors[key]:]
 	eb := NewEventBatch(eventID, opts)
 	if key != KeyOfNoPartitionKey && len(events) > 0 {
 		eb.PartitionKey = events[0].PartitionKey
@@ -118,6 +122,11 @@ func (ebi *EventBatchIterator) Next(eventID string, opts *BatchOptions) (*EventB
 		}
 
 		if !ok {
+			if len(eb.marshaledMessages) == 0 {
+				ebi.Cursors[key]++
+				return nil, ErrMessageIsTooBig
+			}
+
 			return eb, nil
 		}
 		ebi.Cursors[key]++

--- a/batch.go
+++ b/batch.go
@@ -49,6 +49,7 @@ const (
 	KeyOfNoPartitionKey = "NoPartitionKey"
 )
 
+// ErrMessageIsTooBig represents the error when one single event in the batch is bigger than the maximum batch size
 var ErrMessageIsTooBig = errors.New("message is too big")
 
 // BatchWithMaxSizeInBytes configures the EventBatchIterator to fill the batch to the specified max size in bytes

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v3.3.3`
+- EventBatchIterator drops messages which bigger than 1MB with an error
+
 ## `v3.3.2`
 - passing a context to internal calls that use go-amqp that now expect a context
 - updating dependencies in go.mod
@@ -50,7 +53,7 @@
 - cleanup connection after making management request
 
 ## `v1.3.0`
-- add `SystemProperties` to `Event` which contains immutable broker provided metadata (squence number, offset, 
+- add `SystemProperties` to `Event` which contains immutable broker provided metadata (squence number, offset,
   enqueued time)
 
 ## `v1.2.0`
@@ -63,11 +66,11 @@
 - update to amqp 0.11.0 and change sender to use unsettled rather than receiver second mode
 
 ## `v1.1.3`
-- fix leak in partition persistence 
+- fix leak in partition persistence
 - fix discarding event properties on batch sending
 
 ## `v1.1.2`
-- take dep on updated amqp common which has more permissive RPC status description parsing 
+- take dep on updated amqp common which has more permissive RPC status description parsing
 
 ## `v1.1.1`
 - close sender when hub is closed

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package eventhub
 
 const (
 	// Version is the semantic version number
-	Version = "3.3.1"
+	Version = "3.3.3"
 )


### PR DESCRIPTION
### Fix

When batch size is bigger than 1MB the event batch iterator went into an infinite loop. The iterator originally grouped all events by partitionKey and iterate over the groups and then inside the groups, creating EventBatch structures.

There were two errors in the original code: inside one group it iterated over the data in an infinite loop if the group was bigger than the max batch size. The other issue was that it iterated over a map which is not stable, so between iterations the iterator was unstable.

I reimplemented the iterator to keep using grouped events by partitionKey but I use array of grouped events (array of events) over which we can iterate in a stable way.

- [x] All tests passed
- [x] Add change to `changelog.md`

### Environment
- OS: Linux
- Go version: 1.13