### PR TITLE
Feature/with eventhub info in blob path

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v3.3.7`
+- add option to prefix checkpoint blob paths
+
 ## `v3.3.6`
 - fix goroutine leak on listener close
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/url"
 	"sync"
@@ -683,7 +684,7 @@ func startConsumerSpanFromContext(ctx context.Context, operationName string) (ta
 // WithEventhubInfoInBlobPath configures the LeaserCheckpointerOption with a blob path
 func WithEventhubInfoInBlobPath(ehInfo *conn.ParsedConn, consumerGroup string) LeaserCheckpointerOption {
 	return func(ls *LeaserCheckpointer) error {
-		ls.blobPathPrefix = ehInfo.Namespace + "." + ehInfo.Suffix + "/" + ehInfo.HubName + "/" + consumerGroup + "/"
+		ls.blobPathPrefix = fmt.Sprintf("%s.%s/%s/%s/", ehInfo.Namespace, ehInfo.Suffix, ehInfo.HubName, consumerGroup)
 		return nil
 	}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -29,13 +29,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"net/url"
 	"sync"
 	"time"
 
-	"github.com/Azure/azure-amqp-common-go/v3/conn"
 	"github.com/Azure/azure-amqp-common-go/v3/uuid"
 	"github.com/devigned/tab"
 
@@ -681,10 +679,10 @@ func startConsumerSpanFromContext(ctx context.Context, operationName string) (ta
 	return span, ctx
 }
 
-// WithEventhubInfoInBlobPath configures the LeaserCheckpointerOption with a blob path
-func WithEventhubInfoInBlobPath(ehInfo *conn.ParsedConn, consumerGroup string) LeaserCheckpointerOption {
+// WithPrefixInBlobPath is a LeaserCheckpointerOption that adds a prefix to the checkpoint blob path
+func WithPrefixInBlobPath(prefix string) LeaserCheckpointerOption {
 	return func(ls *LeaserCheckpointer) error {
-		ls.blobPathPrefix = fmt.Sprintf("%s.%s/%s/%s/", ehInfo.Namespace, ehInfo.Suffix, ehInfo.HubName, consumerGroup)
+		ls.blobPathPrefix = prefix
 		return nil
 	}
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -38,7 +38,7 @@ import (
 	"github.com/Azure/azure-amqp-common-go/v3/uuid"
 	"github.com/devigned/tab"
 
-	eventhub "github.com/Azure/azure-event-hubs-go/v3"
+	"github.com/Azure/azure-event-hubs-go/v3"
 	"github.com/Azure/azure-event-hubs-go/v3/eph"
 	"github.com/Azure/azure-event-hubs-go/v3/persist"
 

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package eventhub
 
 const (
 	// Version is the semantic version number
-	Version = "3.3.5"
+	Version = "3.3.7"
 )


### PR DESCRIPTION
### Enhancement

The goal of this pull request is to begin harmonizing checkpoint blob paths across azure implementations, as pointed out in this [issue](https://github.com/Azure/azure-event-hubs-go/issues/170).

The proposed enhancement is based on the oft-used variadic function options pattern, so as not to introduce breaking changes.

A similar implementation can be found in the [sender.go](https://github.com/Azure/azure-event-hubs-go/blob/master/sender.go) code (`SendOption`).

This is still a work in progress as it needs to be tested and reviewed.

- [ ] All tests passed
- [x] Add change to `changelog.md`

### Environment
- OS: Write here
- Go version: Write here