### PR TITLE
Remove check for temporary network errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v3.3.5`
+- Remove the check for temporary network errors in sender.go [#80](https://github.com/Azure/azure-event-hubs-go/issues/80)
+
 ## `v3.3.4`
 - read AZURE_ENVIRONMENT variable from environment to use the specified value when creating NewHub
 

--- a/sender.go
+++ b/sender.go
@@ -191,12 +191,6 @@ func (s *sender) trySend(ctx context.Context, evt eventer) error {
 			}
 			switch err.(type) {
 			case *amqp.Error, *amqp.DetachError, net.Error:
-				if netErr, ok := err.(net.Error); ok {
-					if !netErr.Temporary() {
-						return netErr
-					}
-				}
-
 				recvr(err)
 			default:
 				if !isRecoverableCloseError(err) {

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package eventhub
 
 const (
 	// Version is the semantic version number
-	Version = "3.3.4"
+	Version = "3.3.5"
 )


### PR DESCRIPTION
### Fix or Enhancement?
This is a fix to avoid the hub instances to reach an inconsistent state when network errors identified as not temporary happen while sending Eventhub messages. Instead it will rely directly on the recovery backoff mechanism.

Related to https://github.com/Azure/azure-event-hubs-go/issues/80

- [x] All tests passed
- [x] Add change to `changelog.md`

### Environment
- OS: Mac
- Go version: 1.15