### PR TITLE
Unblock receiver goroutine on shutdown

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v3.3.6`
+- fix goroutine leak on listener close
+
 ## `v3.3.5`
 - Remove the check for temporary network errors in sender.go [#80](https://github.com/Azure/azure-event-hubs-go/issues/80)
 


### PR DESCRIPTION
Fixes #204 by wrapping message send in a `select` statement which foregoes sending the message to the handler when a shutdown is initiated.

### Fix or Enhancement?

fix

- [x] All tests passed - a lot of flakiness refreshing auth tokens but otherwise tests passed 
- [x] Add change to `changelog.md`

### Environment
- OS: MacOS Big Sur
- Go version: 1.15