### PR TITLE
Allow customisation of initial checkpoint

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## `v3.3.8`
+- add option to customise initial checkpoint
+
 ## `v3.3.7`
 - add option to prefix checkpoint blob paths
 


### PR DESCRIPTION
### Enhancement

Allow customisation of the initial checkpoint to be created if no existing checkpoint is found.

Use case: For event hubs with large persistence new consumers might not want to start from the earliest possible, but rather from a more recent or the latest checkpoint.

- [x] All tests passed
- [x] Add change to `changelog.md`
