### PR TITLE
return the error from getting the old checkpoint

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## `v3.3.9`
 - update the checkpoint after the receiver options are applied
+- return the error from reading an old checkpoint when initializing the receiver
 
 ## `v3.3.8`
 - add option to customise initial checkpoint

--- a/receiver.go
+++ b/receiver.go
@@ -155,9 +155,10 @@ func (h *Hub) newReceiver(ctx context.Context, partitionID string, opts ...Recei
 	// update checkpoint if no checkpoint is specified and if old checkpoint is successfully read from e.g. file or memory
 	if receiver.checkpoint == (persist.Checkpoint{}) {
 		oldCheckpoint, err := receiver.getLastReceivedCheckpoint()
-		if err == nil {
-			receiver.checkpoint = oldCheckpoint
+		if err != nil {
+			return nil, err
 		}
+		receiver.checkpoint = oldCheckpoint
 	}
 
 	if err := receiver.storeLastReceivedCheckpoint(receiver.checkpoint); err != nil {


### PR DESCRIPTION
Since the checkpoint is now retrieved after applying the options on the receiver, return the error if there is one returned from reading the old checkpoint

Fixes #212