### PR TITLE
Skip calling sender.Recover() for some errors

### DIFF
--- a/sender.go
+++ b/sender.go
@@ -201,6 +201,7 @@ func (s *sender) trySend(ctx context.Context, evt eventer) error {
 				if e.Condition == errorServerBusy || e.Condition == errorTimeout {
 					// don't rebuild the connection in this case, just delay and try again
 					recvr(err, false)
+					break
 				}
 				recvr(err, true)
 			case *amqp.DetachError, net.Error:


### PR DESCRIPTION
For transient errors where we know the connection is good, don't
Recover() the connection as that doesn't really help.

### Fix or Enhancement?


- [ ] All tests passed
- [ ] Add change to `changelog.md`

### Environment
- OS: Write here
- Go version: Write here