### PR TITLE
Enable race detection in integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ test-verbose: ARGS=-v            							## Run tests in verbose mode
 test-debug:   ARGS=-v -debug     							## Run tests in verbose mode with debug output
 test-race:    ARGS=-race         							## Run tests with race detector
 test-cover:   ARGS=-cover -coverprofile=cover.out -v     	## Run tests in verbose mode with coverage
+test-full:    ARGS=-cover -coverprofile=cover.out -v -race	## Run tests with code coverage and race detection
 $(TEST_TARGETS): NAME=$(MAKECMDGOALS:test-%=%)
 $(TEST_TARGETS): test
 check test tests: cyclo lint vet terraform.tfstate; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GOFMT   = gofmt
 GOCYCLO = gocyclo
 GOLINT  = $(BIN)/golint
 GOSTATICCHECK = $(BIN)/staticcheck
+GOJUNITRPT = go-junit-report
 
 V = 0
 Q = $(if $(filter 1,$V),,@)
@@ -37,7 +38,9 @@ test-full:    ARGS=-cover -coverprofile=cover.out -v -race	## Run tests with cod
 $(TEST_TARGETS): NAME=$(MAKECMDGOALS:test-%=%)
 $(TEST_TARGETS): test
 check test tests: cyclo lint vet terraform.tfstate; $(info $(M) running $(NAME:%=% )tests…) @ ## Run tests
-	$(GO) test -timeout $(TIMEOUT)s $(ARGS) ./...
+	$(GO) test -timeout $(TIMEOUT)s $(ARGS) ./... 2>&1 | tee gotestoutput.log && \
+	$(GOJUNITRPT) <  gotestoutput.log > report.xml && \
+	rm -f gotestoutput.log
 
 .PHONY: vet
 vet: ; $(info $(M) running vet…) @ ## Run vet

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build: | ; $(info $(M) building library…) @ ## Build program
 
 # Tests
 
-TEST_TARGETS := test-default test-bench test-verbose test-race test-debug test-cover
+TEST_TARGETS := test-default test-bench test-verbose test-race test-debug test-cover test-full
 .PHONY: $(TEST_TARGETS) test-xml check test tests
 test-bench:   ARGS=-run=__absolutelynothing__ -bench=. 		## Run benchmarks
 test-verbose: ARGS=-v            							## Run tests in verbose mode

--- a/eng/integration-tests.yml
+++ b/eng/integration-tests.yml
@@ -40,7 +40,7 @@ steps:
       export PATH="~/bin:$PATH"
       export GO111MODULE=on
       cd '$(sdkPath)'
-      make test-cover
+      make test-full
       make destroy
       gocov convert cover.out > coverage.json
       gocov-xml < coverage.json > coverage.xml

--- a/hub_test.go
+++ b/hub_test.go
@@ -306,27 +306,6 @@ func (suite *eventHubSuite) TestWebSocket() {
 	}
 }
 
-func (suite *eventHubSuite) TestConcurrency() {
-	tests := map[string]func(context.Context, *testing.T, *Hub, string){
-		"TestConcurrentSendWithRecover": testConcurrentSendWithRecover,
-	}
-
-	for name, testFunc := range tests {
-		setupTestTeardown := func(t *testing.T) {
-			hub, cleanup := suite.RandomHub()
-			defer cleanup()
-			partitionID := (*hub.PartitionIds)[0]
-			client, closer := suite.newClient(t, *hub.Name, HubWithPartitionedSender(partitionID))
-			defer closer()
-			ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-			defer cancel()
-			testFunc(ctx, t, client, partitionID)
-		}
-
-		suite.T().Run(name, setupTestTeardown)
-	}
-}
-
 func testBasicSend(ctx context.Context, t *testing.T, client *Hub, _ string) {
 	err := client.Send(ctx, NewEventFromString("Hello!"))
 	assert.NoError(t, err)
@@ -423,22 +402,6 @@ func testBasicSendAndReceive(ctx context.Context, t *testing.T, client *Hub, par
 		end, _ := ctx.Deadline()
 		waitUntil(t, &wg, time.Until(end))
 	}
-}
-
-func testConcurrentSendWithRecover(ctx context.Context, t *testing.T, client *Hub, _ string) {
-	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			err := client.Send(ctx, NewEventFromString("Hello!"))
-			assert.NoError(t, err)
-			err = client.sender.Recover(ctx)
-			assert.NoError(t, err)
-		}()
-	}
-	end, _ := ctx.Deadline()
-	waitUntil(t, &wg, time.Until(end))
 }
 
 func (suite *eventHubSuite) TestEpochReceivers() {

--- a/races_test.go
+++ b/races_test.go
@@ -1,0 +1,48 @@
+// +build race
+
+package eventhub
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func (suite *eventHubSuite) TestConcurrency() {
+	tests := map[string]func(context.Context, *testing.T, *Hub, string){
+		"TestConcurrentSendWithRecover": testConcurrentSendWithRecover,
+	}
+
+	for name, testFunc := range tests {
+		setupTestTeardown := func(t *testing.T) {
+			hub, cleanup := suite.RandomHub()
+			defer cleanup()
+			partitionID := (*hub.PartitionIds)[0]
+			client, closer := suite.newClient(t, *hub.Name, HubWithPartitionedSender(partitionID))
+			defer closer()
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+			defer cancel()
+			testFunc(ctx, t, client, partitionID)
+		}
+
+		suite.T().Run(name, setupTestTeardown)
+	}
+}
+
+func testConcurrentSendWithRecover(ctx context.Context, t *testing.T, client *Hub, _ string) {
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// we don't check for errors here as the call to Recover()
+			// can cancel any in-flight calls to Send().  this is only
+			// an interesting test when race detection is enabled.
+			client.Send(ctx, NewEventFromString("Hello!"))
+			client.sender.Recover(ctx)
+		}()
+	}
+	end, _ := ctx.Deadline()
+	waitUntil(t, &wg, time.Until(end))
+}


### PR DESCRIPTION
Move tests specific to race detection to their own source file under the
race build tag.
Removed error checking for concurrent test and updated comment.

### Fix or Enhancement?


- [ ] All tests passed
- [ ] Add change to `changelog.md`

### Environment
- OS: Write here
- Go version: Write here