### PR TITLE
Allow for a sender retry cap

### DIFF
--- a/hub_test.go
+++ b/hub_test.go
@@ -327,6 +327,49 @@ func (suite *eventHubSuite) TestConcurrency() {
 	}
 }
 
+func (suite *eventHubSuite) TestSenderRetryOptionsThroughHub() {
+	tests := map[string]func(ctx context.Context, t *testing.T, suite *eventHubSuite, hubName string){
+		"TestWithCustomSenderMaxRetryCount": func(ctx context.Context, t *testing.T, suite *eventHubSuite, hubName string) {
+			client, closer := suite.newClient(t, hubName, HubWithSenderMaxRetryCount(3))
+			defer closer()
+
+			err := client.Send(ctx, &Event{
+				Data: []byte("hello world"),
+			})
+
+			assert.NoError(t, err)
+			assert.EqualValues(t, 3, client.sender.maxRetries)
+			assert.EqualValues(t, client.sender.recoveryBackoff, newSenderRetryOptions().recoveryBackoff)
+		},
+		"TestWithDefaultSenderMaxRetryCount": func(ctx context.Context, t *testing.T, suite *eventHubSuite, hubName string) {
+			client, closer := suite.newClient(t, hubName)
+			defer closer()
+
+			err := client.Send(ctx, &Event{
+				Data: []byte("hello world"),
+			})
+
+			assert.NoError(t, err)
+			assert.EqualValues(t, 5, client.sender.maxRetries)
+			assert.EqualValues(t, client.sender.recoveryBackoff, newSenderRetryOptions().recoveryBackoff)
+		},
+	}
+
+	hub, cleanup := suite.RandomHub()
+	defer cleanup()
+
+	for name, testFunc := range tests {
+		setupTestTeardown := func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+			defer cancel()
+
+			testFunc(ctx, t, suite, *hub.Name)
+		}
+
+		suite.T().Run(name, setupTestTeardown)
+	}
+}
+
 func testBasicSend(ctx context.Context, t *testing.T, client *Hub, _ string) {
 	err := client.Send(ctx, NewEventFromString("Hello!"))
 	assert.NoError(t, err)

--- a/hub_test.go
+++ b/hub_test.go
@@ -317,8 +317,8 @@ func (suite *eventHubSuite) TestSenderRetryOptionsThroughHub() {
 			})
 
 			assert.NoError(t, err)
-			assert.EqualValues(t, 3, client.sender.maxRetries)
-			assert.EqualValues(t, client.sender.recoveryBackoff, newSenderRetryOptions().recoveryBackoff)
+			assert.EqualValues(t, 3, client.sender.retryOptions.maxRetries)
+			assert.EqualValues(t, client.sender.retryOptions.recoveryBackoff, newSenderRetryOptions().recoveryBackoff)
 		},
 		"TestWithDefaultSenderMaxRetryCount": func(ctx context.Context, t *testing.T, suite *eventHubSuite, hubName string) {
 			client, closer := suite.newClient(t, hubName)
@@ -329,8 +329,8 @@ func (suite *eventHubSuite) TestSenderRetryOptionsThroughHub() {
 			})
 
 			assert.NoError(t, err)
-			assert.EqualValues(t, 5, client.sender.maxRetries)
-			assert.EqualValues(t, client.sender.recoveryBackoff, newSenderRetryOptions().recoveryBackoff)
+			assert.EqualValues(t, -1, client.sender.retryOptions.maxRetries)
+			assert.EqualValues(t, client.sender.retryOptions.recoveryBackoff, newSenderRetryOptions().recoveryBackoff)
 		},
 	}
 

--- a/races_test.go
+++ b/races_test.go
@@ -4,6 +4,7 @@ package eventhub
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"sync"
 	"testing"
 	"time"

--- a/sender.go
+++ b/sender.go
@@ -103,10 +103,6 @@ func (h *Hub) newSender(ctx context.Context, retryOptions *senderRetryOptions) (
 	span, ctx := h.startSpanFromContext(ctx, "eh.sender.newSender")
 	defer span.End()
 
-	if retryOptions == nil {
-		return nil, errors.New("retryOptions must be specified")
-	}
-
 	s := &sender{
 		hub:          h,
 		partitionID:  h.senderPartitionID,

--- a/sender.go
+++ b/sender.go
@@ -24,7 +24,6 @@ package eventhub
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"strconv"

--- a/sender_test.go
+++ b/sender_test.go
@@ -1,0 +1,200 @@
+package eventhub
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/Azure/go-amqp"
+	"github.com/stretchr/testify/assert"
+)
+
+// conforms to amqpSender
+type testAmqpSender struct {
+	sendErrors []error
+	sendCount  int
+}
+
+type recoveryCall struct {
+	err     error
+	recover bool
+}
+
+func (s *testAmqpSender) Send(ctx context.Context, msg *amqp.Message) error {
+	var err error
+
+	if len(s.sendErrors) > s.sendCount {
+		err = s.sendErrors[s.sendCount]
+	}
+
+	s.sendCount++
+	return err
+}
+
+func (s *testAmqpSender) Close(ctx context.Context) error {
+	return nil
+}
+
+func TestSenderRetries(t *testing.T) {
+	var recoverCalls []recoveryCall
+
+	var sender *testAmqpSender
+
+	getAmqpSender := func() amqpSender {
+		return sender
+	}
+
+	recover := func(err error, recover bool) {
+		recoverCalls = append(recoverCalls, recoveryCall{err, recover})
+	}
+
+	t.Run("SendOnFirstTry", func(t *testing.T) {
+		recoverCalls = nil
+		sender = &testAmqpSender{}
+
+		err := sendMessage(context.TODO(), getAmqpSender, 3, nil, recover)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 1, sender.sendCount)
+		assert.Empty(t, recoverCalls)
+	})
+
+	t.Run("SendExceedingRetries", func(*testing.T) {
+		recoverCalls = nil
+		sender = &testAmqpSender{
+			sendErrors: []error{
+				amqp.ErrLinkClosed,
+				amqp.ErrSessionClosed,
+				errors.New("We'll never attempt to use this one since we ran out of retries")},
+		}
+
+		actualErr := sendMessage(context.TODO(), getAmqpSender,
+			1, // note we're only allowing 1 retry attempt - so we get the first send() and then 1 additional.
+			nil, recover)
+
+		assert.EqualValues(t, amqp.ErrSessionClosed, actualErr)
+		assert.EqualValues(t, 2, sender.sendCount)
+		assert.EqualValues(t, []recoveryCall{
+			{
+				err:     amqp.ErrLinkClosed,
+				recover: true,
+			},
+			{
+				err:     amqp.ErrSessionClosed,
+				recover: true,
+			},
+		}, recoverCalls)
+
+	})
+
+	t.Run("SendWithUnrecoverableAndNonRetryableError", func(*testing.T) {
+		recoverCalls = nil
+		sender = &testAmqpSender{
+			sendErrors: []error{
+				errors.New("Anything not explicitly retryable kills all retries"),
+				amqp.ErrConnClosed, // we'll never get here.
+			},
+		}
+
+		actualErr := sendMessage(context.TODO(), getAmqpSender, 5, nil, recover)
+
+		assert.EqualValues(t, errors.New("Anything not explicitly retryable kills all retries"), actualErr)
+		assert.EqualValues(t, 1, sender.sendCount)
+		assert.Empty(t, recoverCalls, "No recovery attempts should happen for non-recoverable errors")
+	})
+
+	t.Run("SendWithAmqpErrors", func(*testing.T) {
+		recoverCalls = nil
+		sender = &testAmqpSender{
+			sendErrors: []error{&amqp.Error{
+				// retry but doesn't attempt to recover the connection
+				Condition: errorServerBusy,
+			}, &amqp.Error{
+				// retry but doesn't attempt to recover the connection
+				Condition: errorTimeout,
+			},
+				&amqp.Error{
+					// retry and will attempt to recover the connection
+					Condition: amqp.ErrorNotImplemented,
+				}},
+		}
+
+		err := sendMessage(context.TODO(), getAmqpSender, 6, nil, recover)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 4, sender.sendCount)
+		assert.EqualValues(t, []recoveryCall{
+			{
+				err: &amqp.Error{
+					Condition: errorServerBusy,
+				},
+				recover: false,
+			},
+			{
+				err: &amqp.Error{
+					Condition: errorTimeout,
+				},
+				recover: false,
+			},
+			{
+				err: &amqp.Error{
+					Condition: amqp.ErrorNotImplemented,
+				},
+				recover: true,
+			},
+		}, recoverCalls)
+	})
+
+	t.Run("SendWithDetachOrNetErrors", func(*testing.T) {
+		recoverCalls = nil
+		sender = &testAmqpSender{
+			sendErrors: []error{
+				&amqp.DetachError{},
+				&net.DNSError{},
+			},
+		}
+
+		err := sendMessage(context.TODO(), getAmqpSender, 6, nil, recover)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 3, sender.sendCount)
+		assert.EqualValues(t, []recoveryCall{
+			{
+				err:     &amqp.DetachError{},
+				recover: true,
+			},
+			{
+				err:     &net.DNSError{},
+				recover: true,
+			},
+		}, recoverCalls)
+	})
+
+	t.Run("SendWithRecoverableCloseError", func(*testing.T) {
+		recoverCalls = nil
+		sender = &testAmqpSender{
+			sendErrors: []error{
+				amqp.ErrConnClosed,
+				amqp.ErrLinkClosed,
+				amqp.ErrSessionClosed,
+			},
+		}
+
+		err := sendMessage(context.TODO(), getAmqpSender, 6, nil, recover)
+		assert.NoError(t, err)
+		assert.EqualValues(t, 4, sender.sendCount)
+		assert.EqualValues(t, []recoveryCall{
+			{
+				err:     amqp.ErrConnClosed,
+				recover: true,
+			},
+			{
+				err:     amqp.ErrLinkClosed,
+				recover: true,
+			},
+			{
+				err:     amqp.ErrSessionClosed,
+				recover: true,
+			},
+		}, recoverCalls)
+	})
+
+}


### PR DESCRIPTION
As part of the work @jhendrixMSFT added for recovering sender links we also wanted to allow the customer to cap the # of retries (currently it's infinite so long as the errors are considered retryable).

This PR allows that by exposing a new option as part of the event hub client that allows you to specify the max retry count. It's a small step to also allow configuring the underlying backoff policy details as well but I've purposefully not done that so we can take some time to discuss a possible design for retry policies.

Fixes #216