### PR TITLE
Using new option in go-amqp that lets us keep the link alive after disposition errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 ## `v3.3.13`
 - We no longer close the link when we received disposition errors on sending. This allows 
   us to return errors properly when doing parallel sends on a link that is being 
-  throttled. [PR#TBD]()
+  throttled. [PR#234](https://github.com/Azure/azure-event-hubs-go/pull/234)
 
 ## `v3.3.12`
 - Fix bug in sender.Recover() where recovery could get stuck when a link was throttled. [PR#232](#https://github.com/Azure/azure-event-hubs-go/pull/232)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## `v3.3.13`
+- We no longer close the link when we received disposition errors on sending. This allows 
+  us to return errors properly when doing parallel sends on a link that is being 
+  throttled. [PR#TBD]()
+
 ## `v3.3.12`
 - Fix bug in sender.Recover() where recovery could get stuck when a link was throttled. [PR#232](#https://github.com/Azure/azure-event-hubs-go/pull/232)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## `v3.3.13`
-- We no longer close the link when we received disposition errors on sending. This allows 
+- We no longer close the link when we receive disposition errors on sending. This allows 
   us to return errors properly when doing parallel sends on a link that is being 
   throttled. [PR#234](https://github.com/Azure/azure-event-hubs-go/pull/234)
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/azure-pipeline-go v0.1.9
 	github.com/Azure/azure-sdk-for-go v51.1.0+incompatible
 	github.com/Azure/azure-storage-blob-go v0.6.0
-	github.com/Azure/go-amqp v0.13.10
+	github.com/Azure/go-amqp v0.13.12
 	github.com/Azure/go-autorest/autorest v0.11.18
 	github.com/Azure/go-autorest/autorest/adal v0.9.13
 	github.com/Azure/go-autorest/autorest/azure/auth v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/Azure/azure-storage-blob-go v0.6.0/go.mod h1:oGfmITT1V6x//CswqY2gtAHN
 github.com/Azure/go-amqp v0.13.0/go.mod h1:qj+o8xPCz9tMSbQ83Vp8boHahuRDl5mkNHyt1xlxUTs=
 github.com/Azure/go-amqp v0.13.10 h1:+W1UMoJUFNwyzmslWxhxkM2VZjZprJ2tO2AOYPReeZo=
 github.com/Azure/go-amqp v0.13.10/go.mod h1:D5ZrjQqB1dyp1A+G73xeL/kNn7D5qHJIIsNNps7YNmk=
+github.com/Azure/go-amqp v0.13.12 h1:u/m0QvBgNVlcMqj4bPHxtEyANOzS+cXXndVMYGsC29A=
+github.com/Azure/go-amqp v0.13.12/go.mod h1:D5ZrjQqB1dyp1A+G73xeL/kNn7D5qHJIIsNNps7YNmk=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=

--- a/sender.go
+++ b/sender.go
@@ -369,6 +369,7 @@ func (s *sender) newSessionAndLink(ctx context.Context) error {
 		amqp.LinkSenderSettle(amqp.ModeMixed),
 		amqp.LinkReceiverSettle(amqp.ModeFirst),
 		amqp.LinkTargetAddress(s.getAddress()),
+		amqp.LinkDetachOnDispositionError(false),
 	)
 	if err != nil {
 		tab.For(ctx).Error(err)

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package eventhub
 
 const (
 	// Version is the semantic version number
-	Version = "3.3.9"
+	Version = "3.3.13"
 )


### PR DESCRIPTION
go-amqp would, prior to the recent change in https://github.com/Azure/go-amqp/pull/47, close the link if any disposition errors were returned by the service.

This premature link closing would cause us to unnecessarily thrash if we were being throttled. It could also cause us to return errors even when a batch of messages _had_ been committed by Event Hubs - the disconnect would either interrupt or override the successful result. This was particularly bad when doing many parallel sends on the same link.

We now (for senders) configure the link to not detach on disposition errors. Errors will still be bubbled up to the client but they will be properly sent to the call that failed, rather than to all callers.