### PR TITLE
Installation capability is removed from go get. Need to use go install instead.

### DIFF
--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -36,12 +36,12 @@ jobs:
         displayName: 'Create Go Workspace'
       - script: |
           set -e
-          go get github.com/jstemmer/go-junit-report
-          go get github.com/axw/gocov/gocov
-          go get github.com/AlekSi/gocov-xml
-          go get -u github.com/matm/gocov-html
-          go get -u golang.org/x/lint/golint
-          go get github.com/fzipp/gocyclo/cmd/gocyclo
+          go install github.com/jstemmer/go-junit-report
+          go install github.com/axw/gocov/gocov
+          go install github.com/AlekSi/gocov-xml
+          go install github.com/matm/gocov-html
+          go install golang.org/x/lint/golint
+          go install github.com/fzipp/gocyclo/cmd/gocyclo
         workingDirectory: '$(sdkPath)'
         displayName: 'Install Dependencies'
       - script: |

--- a/eng/integration-tests.yml
+++ b/eng/integration-tests.yml
@@ -25,12 +25,12 @@ steps:
     displayName: 'Create Go Workspace'
   - script: |
       set -e
-      go get github.com/jstemmer/go-junit-report
-      go get github.com/axw/gocov/gocov
-      go get github.com/AlekSi/gocov-xml
-      go get -u github.com/matm/gocov-html
-      go get github.com/fzipp/gocyclo/cmd/gocyclo
-      go get golang.org/x/lint/golint
+      go install github.com/jstemmer/go-junit-report
+      go install github.com/axw/gocov/gocov
+      go install github.com/AlekSi/gocov-xml
+      go install github.com/matm/gocov-html
+      go install github.com/fzipp/gocyclo/cmd/gocyclo
+      go install golang.org/x/lint/golint
     displayName: 'Install Dependencies'
   - script: |
       set -e

--- a/readme.md
+++ b/readme.md
@@ -19,19 +19,19 @@ If you want to use stable versions of the library, please use Go modules.
 
 **NOTE**: versions prior to 3.0.0 depend on pack.ag/amqp which is no longer maintained. Any new code should not use versions prior to 3.0.0.
 
-### Using go get targeting version 3.x.x
+### Using go install targeting version 3.x.x
 ``` bash
-go get -u github.com/Azure/azure-event-hubs-go/v3
+go install github.com/Azure/azure-event-hubs-go/v3
 ```
 
-### Using go get targeting version 2.x.x
+### Using go install targeting version 2.x.x
 ``` bash
-go get -u github.com/Azure/azure-event-hubs-go/v2
+go install github.com/Azure/azure-event-hubs-go/v2
 ```
 
-### Using go get targeting version 1.x.x
+### Using go install targeting version 1.x.x
 ``` bash
-go get -u github.com/Azure/azure-event-hubs-go
+go install github.com/Azure/azure-event-hubs-go
 ```
 
 ## Using Event Hubs
@@ -450,8 +450,8 @@ To setup the integration test environment, ensure the following pre-requisites a
   - export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin
   - export GOPATH=$HOME/go
 - install go dev dependencies
-  - run `go get github.com/fzipp/gocyclo`
-  - run `go get -u golang.org/x/lint/golint`
+  - run `go install github.com/fzipp/gocyclo`
+  - run `go install golang.org/x/lint/golint`
 - run the following bash commands
   - `sudo apt install jq`
 - install gcc


### PR DESCRIPTION
"Starting in Go 1.17, installing executables with go get is deprecated. go install may be used instead."
Source: https://golang.org/doc/go-get-install-deprecation

The -i flag for go install is also deprecated and go install is enough.

Tested with go1.17.2


Enhancement


- [x ] All tests passed
- [ ] Add change to `changelog.md`

### Environment
- OS: Linux/amd64 (Fedora 35)
- Go version: 1.17.2