### PR TITLE
Fixing race condition in LeaserCheckpointer where it can fail with a ContainerAlreadyExists error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## `v3.3.17`
+
+- Fixing issue where the LeaserCheckpointer could fail with a "ContainerAlreadyExists" error. (#253)
+
 ## `v3.3.16`
 
 - Exporting a subset of AMQP message properties for the Dapr project.

--- a/eng/azure-pipelines.yml
+++ b/eng/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
           go get github.com/AlekSi/gocov-xml
           go get -u github.com/matm/gocov-html
           go get -u golang.org/x/lint/golint
-          go get github.com/fzipp/gocyclo/cmd/gocyclo
+          go get github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
         workingDirectory: '$(sdkPath)'
         displayName: 'Install Dependencies'
       - script: |

--- a/eng/integration-tests.yml
+++ b/eng/integration-tests.yml
@@ -29,7 +29,7 @@ steps:
       go get github.com/axw/gocov/gocov
       go get github.com/AlekSi/gocov-xml
       go get -u github.com/matm/gocov-html
-      go get github.com/fzipp/gocyclo/cmd/gocyclo
+      go get github.com/fzipp/gocyclo/cmd/gocyclo@v0.3.1
       go get golang.org/x/lint/golint
     displayName: 'Install Dependencies'
   - script: |

--- a/eng/integration-tests.yml
+++ b/eng/integration-tests.yml
@@ -47,10 +47,10 @@ steps:
       gocov-html < coverage.json > coverage.html
     displayName: 'Run Integration Tests'
     env:
-      ARM_SUBSCRIPTION_ID: $(go-live-azure-subscription-id)
-      ARM_CLIENT_ID: $(go-live-eh-azure-client-id)
-      ARM_CLIENT_SECRET: $(go-live-eh-azure-client-secret)
-      ARM_TENANT_ID: $(go-live-tenant-id)
+      ARM_SUBSCRIPTION_ID: $(aad-azure-sdk-test-subscription-id)
+      ARM_CLIENT_ID: $(aad-azure-sdk-test-client-id)
+      ARM_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
+      ARM_TENANT_ID: $(aad-azure-sdk-test-tenant-id)
 
   - task: PublishTestResults@2
     inputs:

--- a/eng/integration-tests.yml
+++ b/eng/integration-tests.yml
@@ -47,7 +47,7 @@ steps:
       gocov-html < coverage.json > coverage.html
     displayName: 'Run Integration Tests'
     env:
-      ARM_SUBSCRIPTION_ID: $(aad-azure-sdk-test-subscription-id)
+      ARM_SUBSCRIPTION_ID: $(azure-subscription-id)
       ARM_CLIENT_ID: $(aad-azure-sdk-test-client-id)
       ARM_CLIENT_SECRET: $(aad-azure-sdk-test-client-secret)
       ARM_TENANT_ID: $(aad-azure-sdk-test-tenant-id)

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -180,9 +180,8 @@ func (sl *LeaserCheckpointer) EnsureStore(ctx context.Context) error {
 			var storageErr azblob.StorageError
 
 			if errors.As(err, &storageErr) {
-				// if it already exists that's fine. There's a window where we can check that the container
-				// is there and then actually create it - any other consumer can beat us and it's fine.
-
+				// we're okay if the container has been created - we're basically racing against
+				// other LeaserCheckpointers.
 				if storageErr.ServiceCode() != azblob.ServiceCodeContainerAlreadyExists {
 					return err
 				}

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package eventhub
 
 const (
 	// Version is the semantic version number
-	Version = "3.3.13"
+	Version = "3.3.17"
 )


### PR DESCRIPTION
There's a slight race condition between checking the store exists and the container being created.
    
We can handle it easily if we just allow ContainerAlreadyExists to be considered successful. Also, since the storage tests were failing (unrelated to my change) in race detection I also fixed that as well.

Fixes #252
Fixes #225