### PR TITLE
Fixing changelog and version - it was behind so my version bump was incorrect

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,12 @@
 # Change Log
 
-## `v3.3.17`
+## `v3.3.18`
 
 - Fixing issue where the LeaserCheckpointer could fail with a "ContainerAlreadyExists" error. (#253)
+
+## `v3.3.17`
+
+Updating to the latest go-amqp and azure-amqp-common-go to take advantage of some underlying reliability and interface improvements (#245)
 
 ## `v3.3.16`
 

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package eventhub
 
 const (
 	// Version is the semantic version number
-	Version = "3.3.17"
+	Version = "3.3.18"
 )


### PR DESCRIPTION
Changelog and version.go were actually behind by more than one release, so I needed to correct it.