### PR TITLE
add gocyclo back to integration CI

### DIFF
--- a/eng/integration-tests.yml
+++ b/eng/integration-tests.yml
@@ -29,6 +29,7 @@ steps:
       go install github.com/axw/gocov/gocov@v1.1.0
       go install github.com/AlekSi/gocov-xml@v1.0.0
       go install github.com/matm/gocov-html@v0.0.0-20200509184451-71874e2e203b
+      go install github.com/fzipp/gocyclo/cmd/gocyclo@v0.6.0
     displayName: 'Install Dependencies'
   - script: |
       set -e


### PR DESCRIPTION
It's used by the makefile and was inadvertently removed.

### Fix or Enhancement?


- [ ] All tests passed
- [ ] Add change to `changelog.md`

### Environment
- OS: Write here
- Go version: Write here