### PR TITLE
Fixing issue with a lease existing on start

### DIFF
--- a/eph/scheduler.go
+++ b/eph/scheduler.go
@@ -190,7 +190,8 @@ func (s *scheduler) Stop(ctx context.Context) error {
 		if err := lr.Close(ctx); err != nil {
 			lastErr = err
 		}
-		_, _ = s.processor.leaser.ReleaseLease(ctx, lr.lease.GetPartitionID())
+
+		_, _ = s.processor.leaser.ReleaseLease(ctx, lr.getLease().GetPartitionID())
 	}
 
 	return lastErr

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -631,8 +631,8 @@ func (sl *LeaserCheckpointer) createOrGetLease(ctx context.Context, partitionID 
 
 	if err != nil {
 		if storageErr := azblobvendor.StorageError(nil); errors.As(err, &storageErr) &&
-			(storageErr.Response().StatusCode == http.StatusConflict ||
-				storageErr.Response().StatusCode == http.StatusPreconditionFailed) { // blob exists and an actual storage lease is active
+			(storageErr.Response().StatusCode == http.StatusConflict || // blob exists
+				storageErr.Response().StatusCode == http.StatusPreconditionFailed) { // blob exists AND an Azure storage lease is active
 			return sl.getLease(ctx, partitionID)
 		}
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -630,6 +630,12 @@ func (sl *LeaserCheckpointer) createOrGetLease(ctx context.Context, partitionID 
 	})
 
 	if err != nil {
+		if storageErr := azblobvendor.StorageError(nil); errors.As(err, &storageErr) &&
+			(storageErr.Response().StatusCode == http.StatusConflict ||
+				storageErr.Response().StatusCode == http.StatusPreconditionFailed) { // blob exists and an actual storage lease is active
+			return sl.getLease(ctx, partitionID)
+		}
+
 		return nil, err
 	}
 

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -105,6 +105,10 @@ func (ts *testSuite) TestLeaserLeaseEnsure() {
 		lease, err := leaser.EnsureLease(ctx, partitionID)
 		ts.NoError(err)
 		ts.Equal(partitionID, lease.GetPartitionID())
+
+		lease, err = leaser.EnsureLease(ctx, partitionID)
+		ts.NoError(err)
+		ts.Equal(partitionID, lease.GetPartitionID())
 	}
 }
 


### PR DESCRIPTION
Storage failures don't return a Response, and require us to do an errors.As() and check the returned error instead. This checks for the two codes that can come back if the blob already exists (409) or if the blob exists _and_ it has an active storage lease (412).

Fixes #276